### PR TITLE
Add floating download button to ProfileScreen

### DIFF
--- a/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/DownloadFloatingButton.kt
+++ b/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/DownloadFloatingButton.kt
@@ -1,0 +1,26 @@
+package com.codelab.basiclayouts.ui.profile
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun DownloadFloatingButton() {
+    val context = LocalContext.current
+
+    FloatingActionButton(
+        onClick = {
+            val intent = Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("http://47.96.237.130/download")
+            )
+            context.startActivity(intent)
+        }
+    ) {
+        Text(text = "下载新版")
+    }
+}
+

--- a/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/ProfileScreen.kt
@@ -375,6 +375,7 @@ fun ProfileScreen(
 //                context = LocalContext.current
 //            )
 //        },
+        floatingActionButton = { DownloadFloatingButton() },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background
     ) { innerPadding ->


### PR DESCRIPTION
## Summary
- add DownloadFloatingButton composable to open the app update link
- hook the new button into ProfileScreen using Scaffold's floatingActionButton slot

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e5c1637083318e83674d56106d37