### PR TITLE
Add floating download button to ProfileScreen

### DIFF
--- a/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/DownloadFloatingButton.kt
+++ b/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/DownloadFloatingButton.kt
@@ -1,0 +1,58 @@
+package com.codelab.basiclayouts.ui.profile
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GetApp
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.codelab.basiclayouts.R
+
+@Composable
+fun DownloadFloatingButton() {
+    val context = LocalContext.current
+
+    ExtendedFloatingActionButton(
+        onClick = {
+            val intent = Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("http://47.96.237.130/download")
+            )
+            context.startActivity(intent)
+        },
+        icon = {
+            Icon(
+                imageVector = Icons.Filled.GetApp,
+                contentDescription = stringResource(R.string.profile_download_new_version)
+            )
+        },
+        text = { Text(stringResource(R.string.profile_download_new_version)) },
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(
+                brush = Brush.horizontalGradient(
+                    listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.tertiary
+                    )
+                )
+            ),
+        containerColor = Color.Transparent,
+        contentColor = Color.White,
+        elevation = FloatingActionButtonDefaults.elevation(6.dp)
+    )
+}
+

--- a/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/codelab/basiclayouts/ui/screen/profile/ProfileScreen.kt
@@ -375,6 +375,7 @@ fun ProfileScreen(
 //                context = LocalContext.current
 //            )
 //        },
+        floatingActionButton = { DownloadFloatingButton() },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background
     ) { innerPadding ->

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -761,6 +761,7 @@
     <string name="profile_default_user_name">用户</string>
     <string name="profile_edit_profile">编辑资料</string>
     <string name="profile_sign_out">退出登录</string>
+    <string name="profile_download_new_version">下载新版</string>
 
     <!-- Settings Section -->
     <string name="profile_settings_and_support">设置与支持</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -797,6 +797,7 @@
     <string name="profile_default_user_name">User</string>
     <string name="profile_edit_profile">Edit Profile</string>
     <string name="profile_sign_out">Sign Out</string>
+    <string name="profile_download_new_version">Download Update</string>
 
     <!-- Settings Section -->
     <string name="profile_settings_and_support">Settings &amp; Support</string>


### PR DESCRIPTION
## Summary
- add DownloadFloatingButton composable to open the app update link
- style the button with gradient background, icon, and localized strings
- hook the new button into ProfileScreen using Scaffold's floatingActionButton slot

## Testing
- `./gradlew spotlessApply` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e5c1637083318e83674d56106d37